### PR TITLE
Fix eslint errors about mocha

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": "eslint-config-airbnb",
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "globals": {
       "If": true,


### PR DESCRIPTION
Mocha needed to be include in `.eslistrc` env.
