### PR TITLE
Update roboto.scss

### DIFF
--- a/src/containers/App/styles/fonts/roboto.scss
+++ b/src/containers/App/styles/fonts/roboto.scss
@@ -2,4 +2,4 @@
   Fonts
 */
 
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900&subset=latin,cyrillic-ext);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900&subset=latin,cyrillic-ext);


### PR DESCRIPTION
removed http: from import statement. forces an error when attempting to import fonts from an https: server, such as cloud9. removing http: from the URL prefix allows the server to use whichever method is currently being run and the fonts will load
