### PR TITLE
Prevent removing item from toggling checkboxes

### DIFF
--- a/src/components/Items/index.js
+++ b/src/components/Items/index.js
@@ -15,6 +15,7 @@ export class Items extends Component {
   }
 
   onDelete(event) {
+    event.preventDefault();
     const index = event.currentTarget.dataset.index;
     this.props.delItem(index);
   }


### PR DESCRIPTION
Since the "x" is part of the label, a `preventDefault` is required to keep the click from accidentally checking or unchecking other checkboxes.
