### PR TITLE
React-Router 2.0.0-RC4, browserHistory and updated server.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": "eslint-config-airbnb",
   "env": {
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "autoprefixer": "^6.0.2",
     "babel-core": "^6.3.26",
+    "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "redux": "^3.0.4",
     "redux-react-router": "^1.0.0-beta1",
     "react-redux": "^4.0.0",
-    "react-router": "1.0.3",
+    "react-router": "^2.0.0-rc4",
     "jquery": "^2.1.4",
     "bootstrap": "^3.3.5"
   }

--- a/server.js
+++ b/server.js
@@ -1,13 +1,13 @@
-var http = require('http');
-var express = require('express');
-var app = express();
+const http = require('http');
+const express = require('express');
+const app = express();
 
 app.use(require('morgan')('short'));
 
 (function initWebpack() {
-  var webpack = require('webpack');
-  var webpackConfig = require('./webpack/dev.config');
-  var compiler = webpack(webpackConfig);
+  const webpack = require('webpack');
+  const webpackConfig = require('./webpack/dev.config');
+  const compiler = webpack(webpackConfig);
 
   app.use(require('webpack-dev-middleware')(compiler, {
     noInfo: true, publicPath: webpackConfig.output.publicPath,
@@ -20,14 +20,14 @@ app.use(require('morgan')('short'));
   app.use(express.static(__dirname + '/'));
 })();
 
-app.get('/', function root(req, res) {
+app.get(/.*/, function root(req, res) {
   res.sendFile(__dirname + '/index.html');
 });
 
 if (require.main === module) {
-  var server = http.createServer(app);
+  const server = http.createServer(app);
   server.listen(process.env.PORT || 3000, function onListen() {
-    var address = server.address();
+    const address = server.address();
     console.log('Listening on: %j', address);
     console.log(' -> that probably means: http://localhost:%d', address.port);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import createHistory from 'history/lib/createHashHistory';
 import { Provider } from 'react-redux';
-import { Router, Redirect } from 'react-router';
+import { Router, Redirect, browserHistory as history } from 'react-router';
 import configureStore from './store/configureStore';
 import routes from './routes';
 import { syncReduxAndRouter } from 'redux-simple-router';
 
 const store = configureStore();
-const history = createHistory({
-  queryKey: false,
-});
 
 syncReduxAndRouter(history, store);
 


### PR DESCRIPTION
Changed React-Router to new 2.x.x version, updated to use browserHistory instead of hashHistory and updated server.js to catch all and serve index.html
