### PR TITLE
Split webpack configs (lifecycle detection), removed transform-runtime (problems with karma)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,28 @@
 {
-  "presets": [
-    "react",
-    "es2015",
-    "stage-0"
-  ],
-  "plugins": [
-    "transform-runtime",
-    "transform-decorators-legacy"
-  ]
+  	"presets": [
+    	"react",
+    	"es2015",
+    	"stage-0"
+  	],
+  	"plugins": [
+    	"transform-decorators-legacy",
+	],
+	"env": {
+		"start": {
+			"plugins": [
+				[
+					"react-transform", {
+						"transforms": [
+							{
+								"transform": "react-transform-hmr",
+								"imports": ["react"],
+								"locals": ["module"]
+							}
+						]
+					}
+				]
+			]
+		}
+	}
+
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,4 @@
-var path = require('path');
-
-module.exports = function(config) {
+module.exports = (config) => {
   config.set({
     basePath: 'src',
     singleRun: true,
@@ -33,5 +31,4 @@ module.exports = function(config) {
       },
     },
   });
-
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server.js",
     "lint": "eslint src",
-    "build": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js",
+    "build": "webpack --verbose --colors --display-error-details --config webpack/common.config.js",
     "test": "karma start"
   },
   "repository": {
@@ -32,12 +32,14 @@
     "babel-core": "^6.3.26",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "bootstrap-webpack": "0.0.5",
+    "chai": "^3.4.1",
     "classnames": "^2.1.3",
     "css-loader": "^0.23.1",
     "cssnext-loader": "^1.0.1",
@@ -68,6 +70,7 @@
     "react-dom": "^0.14.2",
     "react-hot-loader": "^1.2.7",
     "react-loading-order-with-animation": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
     "redux-form": "^4.0.6",
     "redux-logger": "2.3.1",
     "redux-simple-router": "^1.0.2",
@@ -78,7 +81,8 @@
     "webpack": "^1.9.6",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-dev-server": "^1.8.2",
-    "webpack-hot-middleware": "^2.4.1"
+    "webpack-hot-middleware": "^2.4.1",
+    "webpack-merge": "^0.7.1"
   },
   "dependencies": {
     "babel-runtime": "^6.3.19",

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ app.use(require('morgan')('short'));
 
 (function initWebpack() {
   const webpack = require('webpack');
-  const webpackConfig = require('./webpack/dev.config');
+  const webpackConfig = require('./webpack/common.config');
   const compiler = webpack(webpackConfig);
 
   app.use(require('webpack-dev-middleware')(compiler, {

--- a/webpack/common.config.js
+++ b/webpack/common.config.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const autoprefixer = require('autoprefixer');
+const merge = require('webpack-merge');
+
+const development = require('./dev.config.js');
+const production = require('./prod.config.js');
+
+require('babel-polyfill');
+
+const TARGET = process.env.npm_lifecycle_event;
+
+const PATHS = {
+  app: path.join(__dirname, '../src'),
+  build: path.join(__dirname, '../dist'),
+};
+
+process.env.BABEL_ENV = TARGET;
+
+const common = {
+  entry: PATHS.app,
+
+  output: {
+    path: PATHS.build,
+    filename: 'bundle.js',
+    publicPath: '/dist/',
+  },
+
+  resolve: {
+    extensions: ['', '.jsx', '.js', '.json', '.scss'],
+    modulesDirectories: ['node_modules', PATHS.app],
+  },
+
+  module: {
+    loaders: [{
+      test: /bootstrap\/js\//,
+      loader: 'imports?jQuery=jquery',
+    }, {
+      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/font-woff',
+    }, {
+      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/font-woff2',
+    }, {
+      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/octet-stream',
+    }, {
+      test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/font-otf',
+    }, {
+      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file',
+    }, {
+      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=image/svg+xml',
+    }, {
+      test: /\.js$/,
+      loaders: ['babel-loader'],
+      exclude: /node_modules/,
+    }, {
+      test: /\.scss$/,
+      loader: 'style!css?localIdentName=[path][name]--[local]!postcss-loader!sass',
+    }, {
+      test: /\.png$/,
+      loader: 'file?name=[name].[ext]',
+    }, {
+      test: /\.jpg$/,
+      loader: 'file?name=[name].[ext]',
+    }],
+  },
+
+  postcss: [
+    autoprefixer({ browsers: ['last 2 versions'] }),
+  ],
+};
+
+if (TARGET === 'start' || !TARGET) {
+  module.exports = merge(common, development);
+}
+
+if (TARGET === 'build' || !TARGET) {
+  module.exports = merge(common, production);
+}
+

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -1,7 +1,5 @@
-var path = require('path');
-var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var autoprefixer = require('autoprefixer');
+const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
@@ -10,14 +8,11 @@ module.exports = {
     './src/index',
   ],
 
-  output: {
-    filename: 'bundle.js',
-    path: path.join(__dirname, '/dist/'),
-    publicPath: '/dist/',
-  },
-
   plugins: [
     new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"development"',
+      },
       __DEVELOPMENT__: true,
     }),
     new ExtractTextPlugin('bundle.css'),
@@ -28,51 +23,4 @@ module.exports = {
       jQuery: 'jquery',
     }),
   ],
-
-  resolve: {
-    extensions: ['', '.jsx', '.js', '.json', '.scss'],
-    modulesDirectories: ['node_modules', 'src'],
-  },
-
-  module: {
-    loaders: [{
-      test: /bootstrap\/js\//,
-      loader: 'imports?jQuery=jquery',
-    }, {
-      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-woff',
-    }, {
-      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-woff2',
-    }, {
-      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/octet-stream',
-    }, {
-      test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-otf',
-    }, {
-      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'file',
-    }, {
-      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=image/svg+xml',
-    }, {
-      test: /\.js$/,
-      loaders: ['react-hot', 'babel-loader'],
-      exclude: /node_modules/,
-    }, {
-      test: /\.scss$/,
-      loader: 'style!css?localIdentName=[path][name]--[local]!postcss-loader!sass',
-    }, {
-      test: /\.png$/,
-      loader: 'file?name=[name].[ext]',
-    }, {
-      test: /\.jpg$/,
-      loader: 'file?name=[name].[ext]',
-    }],
-  },
-
-  postcss: [
-    autoprefixer({ browsers: ['last 2 versions'] })
-  ]
 };

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,19 +1,8 @@
-var path = require('path');
-var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var autoprefixer = require('autoprefixer');
+const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
   devtool: 'source-map',
-  entry: [
-    './src/index',
-  ],
-
-  output: {
-    filename: 'bundle.js',
-    path: path.join(__dirname, '../dist/'),
-    publicPath: 'dist/',
-  },
 
   plugins: [
     new webpack.DefinePlugin({
@@ -34,51 +23,4 @@ module.exports = {
       jQuery: 'jquery',
     }),
   ],
-
-  resolve: {
-    extensions: ['', '.jsx', '.js', '.json', '.scss'],
-    modulesDirectories: ['node_modules', 'src'],
-  },
-
-  module: {
-    loaders: [{
-      test: /bootstrap\/js\//,
-      loader: 'imports?jQuery=jquery',
-    }, {
-      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-woff',
-    }, {
-      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-woff2',
-    }, {
-      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/octet-stream',
-    }, {
-      test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=application/font-otf',
-    }, {
-      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'file',
-    }, {
-      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-      loader: 'url?limit=10000&mimetype=image/svg+xml',
-    }, {
-      test: /\.js$/,
-      loaders: ['react-hot', 'babel-loader'],
-      exclude: /node_modules/,
-    }, {
-      test: /\.scss$/,
-      loader: 'style!css!postcss-loader!sass',
-    }, {
-      test: /\.png$/,
-      loader: 'file?name=[name].[ext]',
-    }, {
-      test: /\.jpg$/,
-      loader: 'file?name=[name].[ext]',
-    }],
-  },
-  
-  postcss: [
-    autoprefixer({ browsers: ['last 2 versions'] })
-  ]
 };


### PR DESCRIPTION
Webpack configs are now split into 3 files common, prod and dev. 
Depending on npm lifecycle (start/build) it will merge the right file into the webpack config.

Removed transform-runtime from .babelrc - it has currently problems with Karma

Removed babel hot loaders from webpack configuration and placed them into .babelrc
