### PR TITLE
use babel with server.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,25 +1,11 @@
 {
-  "presets": [
-    "react",
-    "es2015",
-    "stage-0"
-  ],
+  "presets": ["react", "es2015" , "stage-0"],
   "plugins": [
-    "transform-decorators-legacy",
+    ["transform-decorators-legacy"]
   ],
   "env": {
     "start": {
-      "plugins": [
-        [
-          "react-transform", {
-            "transforms": [{
-              "transform": "react-transform-hmr",
-              "imports": ["react"],
-              "locals": ["module"]
-            }]
-          }
-        ]
-      ]
+      "presets": ["react-hmre"]
     }
   }
 }

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,14 @@
+var fs = require('fs');
+
+var babelrc = fs.readFileSync('./.babelrc');
+var config;
+
+try {
+  config = JSON.parse(babelrc);
+} catch (err) {
+  console.error('==>     ERROR: Error parsing your .babelrc.');
+  console.error(err);
+}
+
+require('babel-core/register')(config);
+require('../server');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --progress --verbose --colors --display-error-details --config webpack/common.config.js",
     "build:production": "npm run clean && npm run build",
     "lint": "eslint src",
-    "start": "node server.js",
+    "start": "node bin/server.js",
     "test": "karma start"
   },
   "repository": {
@@ -97,10 +97,11 @@
     "webpack-merge": "^0.7.1"
   },
   "dependencies": {
+    "babel-preset-react-hmre": "^1.0.1",
+    "jquery": "^2.2.0",
     "react": "^0.14.2",
-    "redux": "^3.0.4",
     "react-redux": "^4.0.0",
     "react-router": "^2.0.0-rc4",
-    "jquery": "^2.2.0"
+    "redux": "^3.0.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -24,11 +24,9 @@ app.get(/.*/, function root(req, res) {
   res.sendFile(__dirname + '/index.html');
 });
 
-if (require.main === module) {
-  const server = http.createServer(app);
-  server.listen(process.env.PORT || 3000, function onListen() {
-    const address = server.address();
-    console.log('Listening on: %j', address);
-    console.log(' -> that probably means: http://localhost:%d', address.port);
-  });
-}
+const server = http.createServer(app);
+server.listen(process.env.PORT || 3000, function onListen() {
+  const address = server.address();
+  console.log('Listening on: %j', address);
+  console.log(' -> that probably means: http://localhost:%d', address.port);
+});


### PR DESCRIPTION
1. I found it was not convenient for writing `server.js` without babel , so I change from `node server.js` to  `node bin/server.js`. 
2. When using [react-transform-hmr](https://github.com/gaearon/react-transform-hmr) , I found a  [presets](https://github.com/danmartinez101/babel-preset-react-hmre) wrapped this and used it.

I sent this pull request improving items above. Hope it helps.
