### PR TITLE
Remove react-hot-loader and move babel preset to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
     "bootstrap-loader": "^1.0.2",
     "bootstrap-sass": "^3.3.6",
@@ -78,7 +79,6 @@
     "react-addons-css-transition-group": "^0.14.2",
     "react-document-meta": "^2.0.0-rc2",
     "react-dom": "^0.14.2",
-    "react-hot-loader": "^1.2.7",
     "react-loading-order-with-animation": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redux-form": "^4.0.6",
@@ -97,7 +97,6 @@
     "webpack-merge": "^0.7.1"
   },
   "dependencies": {
-    "babel-preset-react-hmre": "^1.0.1",
     "jquery": "^2.2.0",
     "react": "^0.14.2",
     "react-redux": "^4.0.0",


### PR DESCRIPTION
Remove the unnecessary react-hot-loader package and move babel-preset-react-hmre to devDependencies.
