### PR TITLE
Use a simpler way to specify the middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "react": "^0.14.2",
     "react-redux": "^4.0.0",
     "react-router": "^2.0.0-rc4",
-    "redux": "^3.0.4"
+    "redux": "^3.1.4"
   }
 }

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,21 +1,21 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import createLogger from 'redux-logger';
 import rootReducer from '../reducers';
 
-const logger = createLogger({
-  collapsed: true,
-  predicate: () =>
-    process.env.NODE_ENV === `development`, // eslint-disable-line no-unused-vars
-});
-
-const createStoreWithMiddleware = applyMiddleware(
-  thunkMiddleware,
-  logger
-)(createStore);
+let middleware = [thunkMiddleware];
+if (process.env.NODE_ENV !== 'production') {
+  const createLogger = require('redux-logger');
+  middleware.push(createLogger({
+    collapsed: true
+  }));
+}
 
 export default function configureStore(initialState) {
-  const store = createStoreWithMiddleware(rootReducer, initialState);
+  const store = createStore(
+    rootReducer,
+    initialState,
+    applyMiddleware(...middleware)
+  );
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers


### PR DESCRIPTION
Since 3.1.0 we allow to pass enhancer as third argument to `createStore()`.
This commit also fixes redux-logger being pulled into the production builds.
