### PR TITLE
Re-add history devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "express-open-in-editor": "^1.1.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
+    "history": "^2.0.0",
     "imports-loader": "^0.6.5",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.19",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "express-open-in-editor": "^1.1.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
-    "history": "^2.0.0",
+    "history": "^2.0.0-rc2",
     "imports-loader": "^0.6.5",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.19",


### PR DESCRIPTION
`history` was removed in https://github.com/anorudes/redux-easy-boilerplate/commit/f56d2da794b70270328920e6bf0937a7719922d5 but use of it was re-added in https://github.com/anorudes/redux-easy-boilerplate/commit/1558c1c4764070c5f6b021e8517d097b57edc3bb without re-adding `history` as a devDependency

this causes
 `ERROR in ./src/index.js
Module not found: Error: Cannot resolve module 'history' in C:\code\redux-easy-b                                                                                                                                                                                               oilerplate\src
 @ ./src/index.js 15:15-3`

to be thrown when `npm-start` is run

This pr adds it back
