### PR TITLE
Bugfix/failed actions has no server error

### DIFF
--- a/app/redux/middleware/api.js
+++ b/app/redux/middleware/api.js
@@ -22,7 +22,7 @@ export const apiMiddleware = store => next => action => {
       payload: {
         promise: requestPromise
           .promise()
-          .then(res => res.body)
+          .then(res => res)
           .catch(res => {
             const data = res.res;
             if (action.callback) {

--- a/app/redux/middleware/api.js
+++ b/app/redux/middleware/api.js
@@ -31,6 +31,7 @@ export const apiMiddleware = store => next => action => {
             if (action.onFailure) {
               action.onFailure(data, store.dispatch);
             }
+            return data;
           })
           .tap(res => {
             if (action.callback) {

--- a/app/redux/middleware/promise.js
+++ b/app/redux/middleware/promise.js
@@ -1,8 +1,6 @@
 // Edited promise middleware
 // Original source and docs: https://github.com/pburtchaell/redux-promise-middleware
 
-import R from 'ramda';
-
 const isPromise = (value) => {
   if (value !== null && typeof value === 'object') {
     return value.promise && typeof value.promise.then === 'function';
@@ -54,27 +52,15 @@ export function promiseMiddleware(config = {}) {
        */
       action.payload.promise = promise.then(
         (resolved = {}) => {
-          if (!R.isEmpty(resolved)) {
-            const resolveAction = getResolveAction();
-            return dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
-              ...resolveAction,
-              ...isAction(resolved) ? resolved : {
-                ...!!resolved && {
-                  payload: resolved,
-                },
+          const resolveAction = getResolveAction(resolved && !resolved.ok);
+          return dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
+            ...resolveAction,
+            ...isAction(resolved) ? resolved : {
+              ...!!resolved && {
+                payload: resolved.body,
               },
-            });
-          } else {
-            const resolveAction = getResolveAction(true);
-            return dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
-              ...resolveAction,
-              ...isAction(resolved) ? resolved : {
-                ...!!resolved && {
-                  payload: resolved,
-                },
-              },
-            });
-          }
+            },
+          });
         },
         (rejected = {}) => {
           const resolveAction = getResolveAction(true);


### PR DESCRIPTION
**Bug:** in the reducer of **GET_POSTS_FAILURE** the `payload`is always empty and do not contain the server response.

**Fix:** The `apiMiddleware` do not return the server response on failure to `promiseMiddleware`.
That's why I've added `return data` in the `catch` section of the `apiMiddleware` and then the `promiseMiddleware` set the type of the action `SUCCESS` or `ERROR` depending of `resolved.ok`
